### PR TITLE
codigo: Añade Makefile y hace los ejemplos completos compilables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ por_semestre
 img/dot/*
 img/ditaa/*
 img/gnuplot/*
+codigo/target/*
 notas/sistemas_operativos.*
 notas/sistemas_operativos-blx.bib

--- a/codigo/Makefile
+++ b/codigo/Makefile
@@ -1,0 +1,14 @@
+# TODO: En el futuro es preferible usar una mejor heurística para diferenciar
+# ejemplos completos de pseudocódigo
+SOURCES := $(shell grep -r 'int main' | cut -d ":" -f 1)
+TARGETS := $(patsubst %.c, target/%, $(SOURCES))
+
+CFLAGS := -Wall
+CLINKFLAGS := -pthread
+
+.PHONY: all
+all: $(TARGETS)
+	@echo > /dev/null
+
+target/%: %.c
+	$(CC) $(CFLAGS) $< -o $@ $(CLINKFLAGS)

--- a/codigo/algoritmo_banquero.rb
+++ b/codigo/algoritmo_banquero.rb
@@ -6,10 +6,11 @@ asignado = {'A' => 1, 'B' => 1, 'C' => 2, 'D' => 0, 'E' => 3}
 libres = 2
 
 while ! l.empty? do
-  p = l.select {|id| reclamado[id] - asignado[id] <= libres}.first
+  p = l.find {|id| reclamado[id] - asignado[id] <= libres}
   raise Exception, 'Estado inseguro' if p.nil?
   libres += asignado[p]
   l.delete(p)
   s.push(p)
 end
+
 puts "La secuencia segura encontrada es: " + s.to_s

--- a/codigo/filosofos_monitores.c
+++ b/codigo/filosofos_monitores.c
@@ -1,44 +1,17 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <pthread.h>
+
 /* Implementacion para cinco filósofos */
+#define COUNT 5
+
 #define PENSANDO 1
 #define HAMBRIENTO 2
 #define COMIENDO 3
-pthread_cond_t  VC[5]; /* Una VC por filósofo */
-pthread_mutex_t M;     /* Mutex para el monitor */
-int estado[5];         /* Estado de cada filósofo */
 
-void palillos_init () {
-    int i;
-    pthread_mutex_init(&M, NULL);
-    for (i = 0; i < 5; i++) {
-        pthread_cond_init(&VC[i], NULL);
-        estado[i] = PENSANDO;
-    }
-}
-
-void toma_palillos (int i) {
-    pthread_mutex_lock(&M)
-    estado[i] = HAMBRIENTO;
-    actualiza(i);
-    while (estado[i] == HAMBRIENTO)
-        pthread_cond_wait(&VC[i], &M);
-    pthread_mutex_unlock(&M);
-}
-
-void suelta_palillos (int i) {
-    pthread_mutex_lock(&M)
-    estado[i] = PENSANDO;
-    actualiza((i - 1) % 5);
-    actualiza((i + 1) % 5);
-    pthread_mutex_unlock(&M);
-}
-
-void come(int i) {
-    printf("El filosofo %d esta comiendo\n", i);
-}
-
-void piensa(int i) {
-    printf("El filosofo %d esta pensando\n", i);
-}
+pthread_cond_t VC[COUNT];                      /* Una VC por filósofo */
+pthread_mutex_t M = PTHREAD_MUTEX_INITIALIZER; /* Mutex para el monitor */
+int estado[COUNT];                             /* Estado de cada filósofo */
 
 /* No incluir 'actualiza' en los encabezados, */
 /* es una función interna/privada */
@@ -52,23 +25,68 @@ int actualiza (int i) {
     return 0;
 }
 
+void palillos_init() {
+    int i;
+
+    pthread_mutex_init(&M, NULL);
+    for (i = 0; i < COUNT; i++) {
+        pthread_cond_init(&VC[i], NULL);
+        estado[i] = PENSANDO;
+    }
+}
+
+void toma_palillos (int i) {
+    pthread_mutex_lock(&M);
+    estado[i] = HAMBRIENTO;
+    actualiza(i);
+    while (estado[i] == HAMBRIENTO)
+        pthread_cond_wait(&VC[i], &M);
+    pthread_mutex_unlock(&M);
+}
+
+void suelta_palillos (int i) {
+    pthread_mutex_lock(&M);
+    estado[i] = PENSANDO;
+    actualiza((i - 1) % COUNT);
+    actualiza((i + 1) % COUNT);
+    pthread_mutex_unlock(&M);
+}
+
+void come(int i) {
+    printf("El filosofo %d esta comiendo\n", i);
+}
+
+void piensa(int i) {
+    printf("El filosofo %d esta pensando\n", i);
+}
+
 void *filosofo(void *arg) {
-  int self = *(int *) arg;
-  for (;;) {
-    piensa(self);
-    toma_palillos(self);
-    come(self);
-    suelta_palillos(self);
-  }
+    int self = *(int *) arg;
+    for (;;) {
+        piensa(self);
+        toma_palillos(self);
+        come(self);
+        suelta_palillos(self);
+    }
 }
 
 int main() {
-  int i;
-  pthread_t th[5];  /* IDs de los hilos filósofos */
-  pthread_attr_t attr = NULL;
-  palillos_init();
-  for (i=0; i<5; i++) 
-    pthread_create(&th[i], attr, filosofo, (int*) &i);
-  for (i=0; i<5; i++) 
-    pthread_join(th[i],NULL);
+    int i;
+    int indexes[COUNT];
+
+    pthread_t th[COUNT];  /* IDs de los hilos filósofos */
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+
+    palillos_init();
+
+    for (i = 0; i < COUNT; i++) {
+        indexes[i] = i;
+        pthread_create(th + i, &attr, filosofo, indexes + i);
+    }
+
+    for (i = 0; i < 5; i++)
+        pthread_join(th[i],NULL);
+
+    return 0;
 }

--- a/codigo/rendimiento_en_arreglo.c
+++ b/codigo/rendimiento_en_arreglo.c
@@ -3,59 +3,62 @@
 #define VECES 10
 
 unsigned long timestamp(){
-  /* RDTSCP entrega el valor del contador de tiempo del CPU (TSC), obligando */
-  /* a la serialización (evitando el reordenamiento de instrucciones). */
-  /* Siendo un valor de 64 bits, se recupera de los registros RDX y RAX. */
-  /* */
-  /* Referencias: */
-  /* https://ccsl.carleton.ca/~jamuir/rdtscpm1.pdf */
-  /* http://www.strchr.com/performance_measurements_with_rdtsc */
-  /* https://stackoverflow.com/questions/12631856/difference-between-rdtscp-rdtsc-memory-and-cpuid-rdtsc */
-  long tsc;
-  asm volatile("rdtscp; "         /* Lectura serializada del TSC
-	       "shl $32, %%rdx; " /* Recorre 32 bits bajos de RDX a izq. */
-	       "or %%rdx, %%rax"  /* Combina RDX y RAX */
-	       : "=a"(tsc)        /* Obtiene el valor en la variable tsc */
-	       :
-	       : "%rcx", "%rdx"   /* Registros que son afectados */
-	       );
-  return tsc;
+    /* RDTSCP entrega el valor del contador de tiempo del CPU (TSC), obligando */
+    /* a la serialización (evitando el reordenamiento de instrucciones). */
+    /* Siendo un valor de 64 bits, se recupera de los registros RDX y RAX. */
+    /* */
+    /* Referencias: */
+    /* https://ccsl.carleton.ca/~jamuir/rdtscpm1.pdf */
+    /* http://www.strchr.com/performance_measurements_with_rdtsc */
+    /* https://stackoverflow.com/questions/12631856/difference-between-rdtscp-rdtsc-memory-and-cpuid-rdtsc */
+    long tsc;
+    asm volatile("rdtscp; "         /* Lectura serializada del TSC */
+                 "shl $32, %%rdx; " /* Recorre 32 bits bajos de RDX a izq. */
+                 "or %%rdx, %%rax"    /* Combina RDX y RAX */
+                 : "=a"(tsc)                /* Obtiene el valor en la variable tsc */
+                 :
+                 : "%rcx", "%rdx"     /* Registros que son afectados */
+                 );
+    return tsc;
 }
 
 void llena_arreglo(int modo) {
-  int data[LONGITUD][LONGITUD];
-  int x, y;
-  for (x=0; x < LONGITUD; x++)
-    for (y=0; y < LONGITUD; y++)
-      if (modo)
-	data[y][x] = 1;
-      else
-	data[x][y] = 1;
+    int data[LONGITUD][LONGITUD];
+    int x, y;
+    for (x = 0; x < LONGITUD; x++)
+        for (y = 0; y < LONGITUD; y++)
+            if (modo)
+                data[y][x] = 1;
+            else
+                data[x][y] = 1;
 }
 
-void main(){
-  unsigned long inicio, fin, prom_h, prom_v;
-  printf( "Usando %d bytes de memoria\n", LONGITUD*LONGITUD*sizeof(int));
-  prom_h = 0;
-  prom_v = 0;
+int main(){
+    unsigned long inicio, fin, prom_h, prom_v;
+    int i;
 
-  for (int i=0; i < VECES; i++) {
-    inicio = timestamp();
-    llena_arreglo(0);
-    fin = timestamp();
-    prom_h += (fin-inicio);
-    printf("De %lu a %lu: %lu\n", inicio, fin, fin - inicio);
-  }
-  printf("Promedio (horizontal): %lu\n", prom_h / VECES);
+    printf( "Usando %zu bytes de memoria\n", LONGITUD * LONGITUD * sizeof(int));
+    prom_h = 0;
+    prom_v = 0;
 
-  printf("=========\n");
-  for (int i=0; i < VECES; i++) {
-    inicio = timestamp();
-    llena_arreglo(1);
-    fin = timestamp();
-    prom_v += (fin-inicio);
-    printf("De %lu a %lu: %lu\n", inicio, fin, fin - inicio);
-  }
-  printf("Promedio (vertical): %lu\n", prom_v / VECES);
-  printf("\nRelación (horiz / vert): %f\n", (float) prom_h / prom_v);
+    for (i = 0; i < VECES; i++) {
+        inicio = timestamp();
+        llena_arreglo(0);
+        fin = timestamp();
+        prom_h += (fin-inicio);
+        printf("De %lu a %lu: %lu\n", inicio, fin, fin - inicio);
+    }
+    printf("Promedio (horizontal): %lu\n", prom_h / VECES);
+
+    printf("=========\n");
+    for (i = 0; i < VECES; i++) {
+        inicio = timestamp();
+        llena_arreglo(1);
+        fin = timestamp();
+        prom_v += (fin-inicio);
+        printf("De %lu a %lu: %lu\n", inicio, fin, fin - inicio);
+    }
+    printf("Promedio (vertical): %lu\n", prom_v / VECES);
+    printf("\nRelación (horiz / vert): %f\n", (float) prom_h / prom_v);
+    return 0;
 }


### PR DESCRIPTION
Especialmente preocupante era el siguiente fragmento de código:

```
pthread_create(&th[i], attr, filosofo, (int*) &i);
```

Donde se le pasa un puntero a una variable de la pila a un hilo, cuando
esa variable cambia.

Cabe la posibilidad de que ese hilo no empiece a correr antes de que la
siguiente iteración del bucle se produzca, lo que generaría que varios
filósofos acabaran con la misma id.

He estandarizado el indentado a 4 espacios, pero no hay problema en
cambiarlo a 2 si se quiere.
